### PR TITLE
Use stable Rust: no unstable test feature or bencher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ license = "MIT"
 [dependencies]
 html5ever = "0.25"
 markup5ever_rcdom = "0.1"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "default"
+harness = false

--- a/benches/default.rs
+++ b/benches/default.rs
@@ -1,0 +1,13 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use html5minify::*;
+
+const HTML: &str = "<html> \n<link href=\"test.css\">\n<h2   id=\"id_one\"    >Hello\n</h2>    \n<p>\nWorld</p>";
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("minify", |b| b.iter(|| {
+      black_box(HTML).minify().expect("Failed to minify HTML");
+    }));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(test)]
 #![warn(missing_docs)]
 #![deny(warnings, clippy::pedantic, clippy::nursery)]
 
@@ -304,9 +303,6 @@ fn can_have_children(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
-
-    use self::test::Bencher;
     use super::*;
     use std::str;
 
@@ -321,12 +317,5 @@ mod tests {
         let minified = str::from_utf8(&minified).expect("Failed to convert to string");
 
         assert_eq!(EXPECTED, minified);
-    }
-
-    #[bench]
-    fn bench_minify(b: &mut Bencher) {
-        b.iter(|| {
-            HTML.minify().expect("Failed to minify HTML");
-        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ fn omit_end_element(name: &str) -> bool {
             | "option"
             | "p"
             | "param"
+            | "source"
             | "tbody"
             | "td"
             | "tfoot"
@@ -295,7 +296,6 @@ fn can_have_children(name: &str) -> bool {
             | "link"
             | "meta"
             | "param"
-            | "source"
             | "track"
             | "wbr"
     )


### PR DESCRIPTION
Hi Martin,

First of all thank you for this crate. After some evaluation of the few HTML minifiers this one does the job the best so far.
I haven't made a speed test yet, but this is also less of a concern for me right now.

The only issue I had was that it used an unstable feature, but I'm a big fan of building project with stable Rust.
So I propose a change to use criterion for benchmarking instead.

Bonus: I fixed the `<source>` tag according to [docs].

[docs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source